### PR TITLE
Remove o helper city

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ composer require sysvale/helpers
  * removeCrassLetters
  * validateCpf
  * weekDay
- * city
  * getNFirstWords
 
 

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -561,16 +561,6 @@ class Helpers
     }
 
     /**
-     * @return mixed
-     */
-    public static function city()
-    {
-        $database_id = \Crypt::decrypt(session('database_id'));
-
-        return \App\Database::find($database_id)->city;
-    }
-
-    /**
      * @param string $str
      * @param string $separator
      * @param int $n


### PR DESCRIPTION
Recomendo a remoção deste helper por o mesmo ser muito específico. De acordo com o README do projeto "Php functions to make you work faster." esta função só funcionaria caso o desenvolvedor possuísse uma arquitetura de software semelhante.