### PR TITLE
Altera continue por break

### DIFF
--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -441,7 +441,7 @@ class Helpers
                     }
 
                     if ($i < 2 && $n1 == $n2) {
-                        continue;
+                        break;
                     } elseif ($n1 >= $n2) {
                         return false;
                     }
@@ -453,7 +453,7 @@ class Helpers
                     }
 
                     if ($i < 2 && $n1 == $n2) {
-                        continue;
+                        break;
                     } elseif ($n1 <= $n2) {
                         return false;
                     }


### PR DESCRIPTION
No php 7.4
```
"continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"?

/src/Helpers.php:408
```

Para compatibilidade com PHP 7.4.