### PR TITLE
Implement month abbreviations in Portuguese

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ composer require sysvale/helpers
  * removeAccents
  * compareVersion
  * monthPt
+ * monthPtAbbr
  * removeCrassLetters
  * validateCpf
  * validateCNPJ
@@ -54,7 +55,7 @@ composer require sysvale/helpers
 
 #### maskBank
 ```php
-use Sysvale/Helpers;
+use Sysvale\Helpers;
 
 $bankNumber = 12345;
 
@@ -65,7 +66,7 @@ $maskedBank = Helpers::maskBank($bankNumber);
 
 #### trimpp
 ```php
-use Sysvale/Helpers;
+use Sysvale\Helpers;
 
 $text = " Text \t \n "; //String with spaces and special caracter;
 
@@ -76,13 +77,24 @@ $text = Helpers::trimpp($text);
 
 #### urlNoCache
 ```php
-use Sysvale/Helpers;
+use Sysvale\Helpers;
 
 $url = 'http://url.com.br';
 
 $url = Helpers::urlNoCache($url);
 
 // $url will be http://url.com.br?1570588480
+```
+
+#### monthPtAbbr
+```php
+use Sysvale\Helpers;
+
+$month = 1;
+
+$abbr = Helpers::monthPtAbbr($month);
+
+// $abbr will be Jan
 ```
 
 ## Validate class
@@ -107,7 +119,7 @@ To use the class import as in the example:
 #### isValidCpf
 
 ```php
-use Sysvale/Helpers/Validate;
+use Sysvale\Helpers\Validate;
 
 $value = '334.734.750-17';
 
@@ -119,7 +131,7 @@ $isValid = Validate::isValidCpf($value);
 #### isValidCnpj
 
 ```php
-use Sysvale/Helpers/Validate;
+use Sysvale\Helpers\Validate;
 
 $value = '56.396.710/0001-37';
 
@@ -131,7 +143,7 @@ $isValid = Validate::isValidCnpj($value);
 #### isValidPhone
 
 ```php
-use Sysvale/Helpers/Validate;
+use Sysvale\Helpers\Validate;
 
 $value = '79988001010';
 
@@ -143,7 +155,7 @@ $isValid = Validate::isValidPhone($value);
 #### isValidResidentialPhone
 
 ```php
-use Sysvale/Helpers/Validate;
+use Sysvale\Helpers\Validate;
 
 $value = '7033662200';
 
@@ -155,7 +167,7 @@ $isValid = Validate::isValidResidentialPhone($value);
 #### isValidMobilePhone
 
 ```php
-use Sysvale/Helpers/Validate;
+use Sysvale\Helpers\Validate;
 
 $value = '70993662200';
 

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -434,6 +434,15 @@ class Helpers
     }
 
     /**
+     * @param int $value
+     * @return string|null
+     */
+    public static function monthPtAbbr($value)
+    {
+        return Dates::getMonthAbbrPtBr($value);
+    }
+
+    /**
      * @param string $str
      * @return string
      */

--- a/src/Helpers/Dates.php
+++ b/src/Helpers/Dates.php
@@ -50,6 +50,32 @@ class Dates
     }
 
     /**
+     * @param int $value
+     * @return string|null
+     */
+    public static function getMonthAbbrPtBr($value)
+    {
+        $months = [
+            1 => 'Jan',
+            2 => 'Fev',
+            3 => 'Mar',
+            4 => 'Abr',
+            5 => 'Mai',
+            6 => 'Jun',
+            7 => 'Jul',
+            8 => 'Ago',
+            9 => 'Set',
+            10 => 'Out',
+            11 => 'Nov',
+            12 => 'Dez',
+        ];
+
+        $value = (int) $value;
+
+        return 1 <= $value && $value <= 12 ? $months[$value] : null;
+    }
+
+    /**
      * @param string $date
      * @return array|string
      * @throws \Exception

--- a/tests/Helpers/DatesTest.php
+++ b/tests/Helpers/DatesTest.php
@@ -34,6 +34,29 @@ class DatesTest extends TestCase
         $this->assertEquals("Dezembro", Dates::getMonthNamePtBr(12));
     }
 
+    public function testGetMonthAbbrPtBrIsCorrect()
+    {
+        $this->assertEquals("Jan", Dates::getMonthAbbrPtBr(1));
+        $this->assertEquals("Fev", Dates::getMonthAbbrPtBr(2));
+        $this->assertEquals("Mar", Dates::getMonthAbbrPtBr(3));
+        $this->assertEquals("Abr", Dates::getMonthAbbrPtBr(4));
+        $this->assertEquals("Mai", Dates::getMonthAbbrPtBr(5));
+        $this->assertEquals("Jun", Dates::getMonthAbbrPtBr(6));
+        $this->assertEquals("Jul", Dates::getMonthAbbrPtBr(7));
+        $this->assertEquals("Ago", Dates::getMonthAbbrPtBr(8));
+        $this->assertEquals("Set", Dates::getMonthAbbrPtBr(9));
+        $this->assertEquals("Out", Dates::getMonthAbbrPtBr(10));
+        $this->assertEquals("Nov", Dates::getMonthAbbrPtBr(11));
+        $this->assertEquals("Dez", Dates::getMonthAbbrPtBr(12));
+    }
+
+    public function testGetMonthAbbrPtBrReturnsNullForInvalidInput()
+    {
+        $this->assertNull(Dates::getMonthAbbrPtBr(0));
+        $this->assertNull(Dates::getMonthAbbrPtBr(13));
+        $this->assertNull(Dates::getMonthAbbrPtBr(-1));
+    }
+
     public function testPtDate2IsoDate()
     {
         $date = '01/02/2003';

--- a/tests/HelpersTest.php
+++ b/tests/HelpersTest.php
@@ -151,6 +151,28 @@ class HelpersTest extends TestCase
         $this->assertEquals("Dezembro", Helpers::monthPt(12));
     }
 
+    public function testMonthPtAbbr()
+    {
+        $this->assertEquals("Jan", Helpers::monthPtAbbr(1));
+        $this->assertEquals("Fev", Helpers::monthPtAbbr(2));
+        $this->assertEquals("Mar", Helpers::monthPtAbbr(3));
+        $this->assertEquals("Abr", Helpers::monthPtAbbr(4));
+        $this->assertEquals("Mai", Helpers::monthPtAbbr(5));
+        $this->assertEquals("Jun", Helpers::monthPtAbbr(6));
+        $this->assertEquals("Jul", Helpers::monthPtAbbr(7));
+        $this->assertEquals("Ago", Helpers::monthPtAbbr(8));
+        $this->assertEquals("Set", Helpers::monthPtAbbr(9));
+        $this->assertEquals("Out", Helpers::monthPtAbbr(10));
+        $this->assertEquals("Nov", Helpers::monthPtAbbr(11));
+        $this->assertEquals("Dez", Helpers::monthPtAbbr(12));
+    }
+
+    public function testMonthPtAbbrReturnsNullForInvalidInput()
+    {
+        $this->assertNull(Helpers::monthPtAbbr(0));
+        $this->assertNull(Helpers::monthPtAbbr(13));
+    }
+
     public function testUnMaskCpf()
     {
         $actual = "77298408631";


### PR DESCRIPTION
Implemented the requested feature to provide Portuguese month abbreviations.
Added `monthPtAbbr` method to `Helpers` and `getMonthAbbrPtBr` to `Dates`.
The implementation follows the 1-12 range and returns `null` for invalid inputs.
Added comprehensive unit tests and updated documentation.
Also took the opportunity to fix incorrect namespace separators (forward slashes to backslashes) in the README usage examples.

---
*PR created automatically by Jules for task [9740604855527301040](https://jules.google.com/task/9740604855527301040) started by @geidsonc*